### PR TITLE
Check array bounds when reading from preferences

### DIFF
--- a/SoundflowerBed/AppController.mm
+++ b/SoundflowerBed/AppController.mm
@@ -1208,7 +1208,7 @@ MySleepCallBack(void * x, io_service_t y, natural_t messageType, void * messageA
 	CFStringRef arrayName = [self formDevicePrefName:is2ch];
 	CFArrayRef mapArray = (CFArrayRef) CFPreferencesCopyAppValue(arrayName, kCFPreferencesCurrentApplication);
 	
-	if (mapArray) {
+	if (mapArray && CFArrayGetCount(mapArray) >= numChans) {
 		for (int i = 0; i < numChans; i++) {
 			CFNumberRef num = (CFNumberRef)CFArrayGetValueAtIndex(mapArray, i);
 			if (num) {


### PR DESCRIPTION
Sometimes an array read from preferences is not the expected length, and leads to a crash in `CFArrayGetValueAtIndex`.