### PR TITLE
Added: list of additional files to check during uninstall of older ve…

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -18,6 +18,11 @@ Then inside that folder, look for a "Soundflower.kext" file. If there is one,
 
 /System/Library/Extensions
 
+Consider also checking for the following files for old installations and likewise deleting them: (These are previously cited in `https://github.com/RogueAmoeba/Soundflower-Original/blob/master/Tools/Uninstall%20Soundflower.scpt`)
+- /Library/Receipts/SoundFlower*
+- /var/db/receipts/com.cycling74.soundflower.*
+- /Applications/Soundflower
+
 **RESTART** your computer
 
 


### PR DESCRIPTION
…rsions


I had 1.6.6 installed (IIRC), and there were additional paths not covered in the uninstall section of the Readme.md file. Note that I have tested removal of all of the paths covered in my change *except for* the `/var/db/receipts/com.cycling74.soundflower.*` files. 

I'm happy to also test removal of those files if someone more familiar with the files can tell me that they're safe to remove.

![screen shot 2018-09-06 at 5 25 14 pm](https://user-images.githubusercontent.com/946790/45194496-571d4100-b221-11e8-9b86-154d755b192a.png)
