### PR TITLE
Changes to enable the build process to work on Xcode 10.1 / OS X High…

### DIFF
--- a/SoundflowerBed/AppController.mm
+++ b/SoundflowerBed/AppController.mm
@@ -7,6 +7,11 @@
 #include <CoreServices/CoreServices.h>
 #include <CoreAudio/CoreAudio.h>
 
+/* verify_noerr was deprecated and removed in OS X High Sierra */
+#ifndef verify_noerr
+#define verify_noerr __Verify_noErr
+#endif
+
 @implementation AppController
 
 void	CheckErr(OSStatus err)

--- a/SoundflowerBed/AudioDevice.cpp
+++ b/SoundflowerBed/AudioDevice.cpp
@@ -42,6 +42,11 @@
 
 #include "AudioDevice.h"
 
+/* verify_noerr was deprecated and removed in OS X High Sierra */
+#ifndef verify_noerr
+#define verify_noerr __Verify_noErr
+#endif
+
 void	AudioDevice::Init(AudioDeviceID devid, bool isInput)
 {
 	mID = devid;

--- a/SoundflowerBed/AudioDeviceList.cpp
+++ b/SoundflowerBed/AudioDeviceList.cpp
@@ -43,6 +43,11 @@
 #include "AudioDeviceList.h"
 #include "AudioDevice.h"
 
+/* verify_noerr was deprecated and removed in OS X High Sierra */
+#ifndef verify_noerr
+#define verify_noerr __Verify_noErr
+#endif
+
 AudioDeviceList::AudioDeviceList(bool inputs) :
 	mInputs(inputs)
 {

--- a/SoundflowerBed/AudioThruEngine.cpp
+++ b/SoundflowerBed/AudioThruEngine.cpp
@@ -49,6 +49,11 @@
 AudioBufferList *gInputIOBuffer = NULL;
 #endif
 
+/* verify_noerr was deprecated and removed in OS X High Sierra */
+#ifndef verify_noerr
+#define verify_noerr __Verify_noErr
+#endif
+
 #define kSecondsInRingBuffer 2.
 
 AudioThruEngine::AudioThruEngine() : 

--- a/SoundflowerBed/Soundflowerbed.xcodeproj/project.pbxproj
+++ b/SoundflowerBed/Soundflowerbed.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 22952B1E104EC967003AF61F /* Soundflower.xcconfig */;
 			buildSettings = {
+				CLANG_CXX_LIBRARY = "libc++";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEPLOYMENT_LOCATION = YES;
@@ -326,6 +327,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = /Applications/Soundflower;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = Soundflowerbed;
 				SECTORDER_FLAGS = "";
 				WARNING_CFLAGS = (
@@ -340,6 +342,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 22952B1E104EC967003AF61F /* Soundflower.xcconfig */;
 			buildSettings = {
+				CLANG_CXX_LIBRARY = "libc++";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEPLOYMENT_LOCATION = YES;
@@ -347,6 +350,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = /Applications/Soundflower;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = Soundflowerbed;
 				SECTORDER_FLAGS = "";
 				WARNING_CFLAGS = (

--- a/Tools/build.rb
+++ b/Tools/build.rb
@@ -51,12 +51,12 @@ end
 `sudo chown -R root #{@svn_root}/Build/InstallerRoot/System/Library/Extensions/Soundflower.kext`
 `sudo chgrp -R wheel #{@svn_root}/Build/InstallerRoot/System/Library/Extensions/Soundflower.kext`
 
-#if /BUILD SUCCEEDED/.match(out)
-#  puts "    BUILD SUCCEEDED"
-#  puts `ruby #{@svn_root}/Tools/load.rb`
-#else
-#  puts "    BUILD FAILED"
-#end
+if /BUILD SUCCEEDED/.match(out)
+  puts "    BUILD SUCCEEDED"
+  puts `ruby #{@svn_root}/Tools/load.rb`
+else
+  puts "    BUILD FAILED"
+end
 
 
 ###################################################################


### PR DESCRIPTION
… Sierra.

- The verify_noerr macro has been removed in High Sierra, so a macro has been added to utilize the alternative __Verify_noErr
- The path to the compiled .kext module in build.rb did not match the location on disk where it was being built.
  This has been correct from Build/InstallerRoot/System/Library/Extensions/Soundflower.kext to Build/InstallerRoot/Library/Extensions/Soundflower.kext

These appear to be the minimal changes required for the kernel module to build cleanly on the combination of Xcode 10.1 and High Sierra.